### PR TITLE
reference the go tools instead of make in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ Run `homer --help` for usage info.
 
 ### building
 
-Build `homer` with a working Go toolchain and `make install`.
+Build `homer` with a working Go toolchain and `go get github.com/blinsay/homer`
 


### PR DESCRIPTION
The make stuff isn't needed and it's more standard to use `go`.